### PR TITLE
Fix docstring warnings by escaping single quotes

### DIFF
--- a/cort.el
+++ b/cort.el
@@ -208,19 +208,19 @@ Eval BEFOREFN and AFTERFN."
 Example:
   (cort-deftest-with-macroexpand-let leaf/leaf
       ((leaf-expand-leaf-protect t))
-    '(((prog1 'leaf
+    \='(((prog1 \='leaf
          (leaf-handler-leaf-protect leaf
            (leaf-init)))
        (leaf leaf
          :config (leaf-init)))))
 
    => (cort-deftest leaf/leaf
-        '((:equal
-           '(let ((leaf-expand-leaf-protect t))
+        \='((:equal
+           \='(let ((leaf-expand-leaf-protect t))
              (macroexpand-1
-              '(leaf leaf
+              \='(leaf leaf
                  :config (leaf-init))))
-           (prog1 'leaf
+           (prog1 \='leaf
               (leaf-handler-leaf-protect leaf
                 (leaf-init))))))"
   `',(mapcar (lambda (elm)


### PR DESCRIPTION
Escaped unquoted single quotes in docstrings to resolve the following warnings.

## Description

In cort.el, certain docstrings caused warnings due to unescaped single quotes, as shown below:

```
In cort-generate--macroexpand-let:
cort.el:205:2: Warning: docstring has wrong usage of unescaped single quotes
    (use \=' or different quoting such as `...')
```

This PR resolves these warnings by adding \= before unquoted single quotes throughout the affected docstrings, ensuring they follow the recommended quoting conventions.

BTW,  I've assign FSF.
