### PR TITLE
fix: correct cort--autoload-do-load early return to fix CI lint

### DIFF
--- a/cort.el
+++ b/cort.el
@@ -79,26 +79,25 @@ This function is polyfill for Emacs<24.4."
 Please see original function for FUNDEF, FUNNAME, MACRO-ONLY usage."
   (if (or (not (consp fundef)) (not (eq 'autoload (car fundef))))
       fundef
-    (when (eq macro-only 'macro)
-      (let ((kind (nth 4 fundef)))
-        (when (not (or (eq kind t) (eq kind 'macro)))
-          fundef)))
-    (when purify-flag
-      (error "Attempt to autoload %s while preparing to dump" (symbol-name funname)))
     (let ((kind (nth 4 fundef)))
-      (unwind-protect
-          (let ((ignore-errors (if (or (eq kind t) (eq kind 'macro)) nil macro-only)))
-            (load (cadr fundef) ignore-errors t nil t))
-        ;; FIXME: revert partially performed defuns
-        ))
-    (if (null funname)
-        nil
-      (let ((fun (indirect-function funname)))
-        (if (equal fun fundef)
-            (error "Autoloading file %s failed to define function %s"
-                   (caar load-history)
-                   (symbol-name funname))
-          fun)))))
+      (if (and (eq macro-only 'macro)
+               (not (or (eq kind t) (eq kind 'macro))))
+          fundef
+        (when purify-flag
+          (error "Attempt to autoload %s while preparing to dump" (symbol-name funname)))
+        (unwind-protect
+            (let ((ignore-errors (if (or (eq kind t) (eq kind 'macro)) nil macro-only)))
+              (load (cadr fundef) ignore-errors t nil t))
+          ;; FIXME: revert partially performed defuns
+          )
+        (if (null funname)
+            nil
+          (let ((fun (indirect-function funname)))
+            (if (equal fun fundef)
+                (error "Autoloading file %s failed to define function %s"
+                       (caar load-history)
+                       (symbol-name funname))
+              fun)))))))
 
 (defun cort--autoloadp (object)
   "Non-nil if OBJECT is an autoload.


### PR DESCRIPTION
## Root cause

The `lint` job (the only failing job — all `test` matrix jobs across Emacs 26.3 → snapshot pass) fails because `keg lint`'s byte-compile phase treats *any* `*Compile-Log*` output as failure, and the modern Emacs byte-compiler now emits:

```
cort.el:83:20: Warning: value returned from (nth 4 fundef) is unused
```

The flagged code in `cort--autoload-do-load` was:

```elisp
(when (eq macro-only 'macro)
  (let ((kind (nth 4 fundef)))
    (when (not (or (eq kind t) (eq kind 'macro)))
      fundef)))
```

This was meant to early-return `fundef` for non-macro autoloads when `macro-only` is `'macro` (mirroring the real `autoload-do-load`), but a bare `when` does not return from the enclosing function — the value is simply computed and discarded. So it was both a latent no-op bug and, with newer byte-compilers, a hard CI failure.

## Fix

Restructured the guard into a single `let`/`if` so the non-macro autoload case actually returns early as intended, matching upstream `autoload-do-load` semantics. This removes the discarded value (silencing the warning) and removes the now-redundant duplicate `(let ((kind ...)))`. No behavior change for the load path; the previously-dead early return is now effective.

## Verification

- `keg lint` → exit 0 (clean: package-lint, byte-compile, checkdoc)
- `make test` → `Run 46 Tests, 46 Expected, 0 Failed, 0 Errored` on Emacs 29.3

https://claude.ai/code/session_012cLbiMLKXxbAPXY5hWuV4z

---
_Generated by [Claude Code](https://claude.ai/code/session_012cLbiMLKXxbAPXY5hWuV4z)_