### PR TITLE
chore: update dependencies to latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
           - '29.2'
           - '29.3'
           - '29.4'
+          - '30.1'
+          - '30.2'
           - 'snapshot'
         include:
           - emacs_version: 'snapshot'

--- a/cort.el
+++ b/cort.el
@@ -7,7 +7,7 @@
 ;; Keywords: test lisp
 ;; Version: 7.2.0
 ;; URL: https://github.com/conao3/cort.el
-;; Package-Requires: ((emacs "24.1") (ansi "0.4") (cl-lib "0.6"))
+;; Package-Requires: ((emacs "24.1") (ansi "0.4.1") (cl-lib "0.7.1"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Summary

Modernizes the project's dependencies to their latest compatible versions.

### `Package-Requires` (cort.el)
- `ansi`: `0.4` -> `0.4.1` (latest stable)
- `cl-lib`: `0.6` -> `0.7.1` (latest GNU ELPA)
- `emacs`: left at `24.1` (a floor bump is a compatibility decision out of scope for a dependency refresh)

### CI (`.github/workflows/test.yml`)
- Added `30.1` and `30.2` to the Emacs test matrix (`30.2` is the newest stable Emacs release)
- `actions/checkout` is already at `v6`; `purcell/setup-emacs` and `conao3/setup-keg` track `master` (no semver tags published) and are left as-is

### Notes
- The `Keg` file declares no development dependencies, and this ecosystem has no lockfile, so nothing else to pin.
- No major upgrades had to be deferred — all bumps are minor and build green.

## Test plan
- [x] `batch-byte-compile cort.el` clean (no warnings) on Emacs 29.3 with `ansi` 0.4.1
- [x] `cort-test-run`: 46/46 tests pass
- [ ] CI green across the full Emacs matrix (26.3 -> 30.2)

https://claude.ai/code/session_01NMVSwMwPCK1hDAWygjmvg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMVSwMwPCK1hDAWygjmvg5)_